### PR TITLE
Node 4 support: switch from i2c to i2c-bus library

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/dwisk/Node_MPR121",
   "dependencies": {
-    "i2c": "^0.2.1"
+    "i2c-bus": "^1.0.2"
   }
 }


### PR DESCRIPTION
First of all, thank you for creating this library!

I made this change because the `i2c` package does not support node 4.x and newer. Switching to `i2c-bus` fixes that.

I'd really appreciate if you could merge this and publish a new release. I am giving a talk in a javascript conference next week, and would really like to use this library in my demo.

Thanks!
